### PR TITLE
Add platform-specific source files to CMake build

### DIFF
--- a/libsdhcdrivers/CMakeLists.txt
+++ b/libsdhcdrivers/CMakeLists.txt
@@ -14,7 +14,7 @@ cmake_minimum_required(VERSION 3.7.2)
 
 project(libsdhcdrivers C)
 
-file(GLOB deps src/*.c)
+file(GLOB deps src/*.c src/plat/${KernelPlatform}/*.c)
 
 list(SORT deps)
 


### PR DESCRIPTION
Only the top level c files were included as sources to the sdhcdrivers
library when using the new CMake build system. This commit adds the
platform-specific c files within src/plat/${KernelPlatform}/.