### PR TITLE
avoid compiler warnings

### DIFF
--- a/libvirtqueue/include/virtqueue.h
+++ b/libvirtqueue/include/virtqueue.h
@@ -68,9 +68,9 @@ typedef struct virtqueue_device {
 
     unsigned a_ring_last_seen;  /* Index of the last seen element in the available ring */
 
-    volatile struct vq_vring_avail *avail_ring; /* The available ring */
-    volatile struct vq_vring_used *used_ring;   /* The used ring */
-    volatile struct vq_vring_desc *desc_table;  /* The descriptor table */
+    struct vq_vring_avail *avail_ring; /* The available ring */
+    struct vq_vring_used *used_ring;   /* The used ring */
+    struct vq_vring_desc *desc_table;  /* The descriptor table */
 } virtqueue_device_t;
 
 /* A driver-side virtqueue */
@@ -81,9 +81,9 @@ typedef struct virtqueue_driver {
     unsigned free_desc_head;    /* The head of the free list in the descriptor table */
     unsigned u_ring_last_seen;  /* Index of the last seen element in the used ring */
 
-    volatile struct vq_vring_avail *avail_ring; /* The available ring */
-    volatile struct vq_vring_used *used_ring;   /* The used ring */
-    volatile struct vq_vring_desc *desc_table;  /* The descritor table */
+    struct vq_vring_avail *avail_ring; /* The available ring */
+    struct vq_vring_used *used_ring;   /* The used ring */
+    struct vq_vring_desc *desc_table;  /* The descritor table */
 } virtqueue_driver_t;
 
 /* Initialise a driver-side virtqueue.
@@ -94,8 +94,8 @@ typedef struct virtqueue_driver {
  * @param notify the notify function to wake up device side
  * @param cookie user's cookie
  */
-void virtqueue_init_driver(virtqueue_driver_t *vq, volatile vq_vring_avail_t *avail_ring,
-                           volatile vq_vring_used_t *used_ring, volatile vq_vring_desc_t *desc, void (*notify)(void),
+void virtqueue_init_driver(virtqueue_driver_t *vq, vq_vring_avail_t *avail_ring,
+                           vq_vring_used_t *used_ring, vq_vring_desc_t *desc, void (*notify)(void),
                            void *cookie);
 
 /* Initialise a device-side virtqueue.
@@ -106,18 +106,18 @@ void virtqueue_init_driver(virtqueue_driver_t *vq, volatile vq_vring_avail_t *av
  * @param notify the notify function to wake up driver side
  * @param cookie user's cookie
  */
-void virtqueue_init_device(virtqueue_device_t *vq, volatile vq_vring_avail_t *avail_ring,
-                           volatile vq_vring_used_t *used_ring, volatile vq_vring_desc_t *desc, void (*notify)(void),
+void virtqueue_init_device(virtqueue_device_t *vq, vq_vring_avail_t *avail_ring,
+                           vq_vring_used_t *used_ring, vq_vring_desc_t *desc, void (*notify)(void),
                            void *cookie);
 
 /* Initialise the descriptor table (create the free list) */
-void virtqueue_init_desc_table(volatile vq_vring_desc_t *table);
+void virtqueue_init_desc_table(vq_vring_desc_t *table);
 
 /* Initialise the available ring */
-void virtqueue_init_avail_ring(volatile vq_vring_avail_t *ring);
+void virtqueue_init_avail_ring(vq_vring_avail_t *ring);
 
 /* Initialise the used ring */
-void virtqueue_init_used_ring(volatile vq_vring_used_t *ring);
+void virtqueue_init_used_ring(vq_vring_used_t *ring);
 
 /** Driver side **/
 

--- a/libvirtqueue/src/virtqueue.c
+++ b/libvirtqueue/src/virtqueue.c
@@ -12,8 +12,8 @@
 
 #include <virtqueue.h>
 
-void virtqueue_init_driver(virtqueue_driver_t *vq, volatile vq_vring_avail_t *avail_ring,
-                           volatile vq_vring_used_t *used_ring, volatile vq_vring_desc_t *desc, void (*notify)(void),
+void virtqueue_init_driver(virtqueue_driver_t *vq, vq_vring_avail_t *avail_ring,
+                           vq_vring_used_t *used_ring, vq_vring_desc_t *desc, void (*notify)(void),
                            void *cookie)
 {
     vq->free_desc_head = 0;
@@ -25,8 +25,8 @@ void virtqueue_init_driver(virtqueue_driver_t *vq, volatile vq_vring_avail_t *av
     vq->cookie = cookie;
 }
 
-void virtqueue_init_device(virtqueue_device_t *vq, volatile vq_vring_avail_t *avail_ring,
-                           volatile vq_vring_used_t *used_ring, volatile vq_vring_desc_t *desc, void (*notify)(void),
+void virtqueue_init_device(virtqueue_device_t *vq, vq_vring_avail_t *avail_ring,
+                           vq_vring_used_t *used_ring, vq_vring_desc_t *desc, void (*notify)(void),
                            void *cookie)
 {
     vq->a_ring_last_seen = RING_SIZE - 1;
@@ -37,7 +37,7 @@ void virtqueue_init_device(virtqueue_device_t *vq, volatile vq_vring_avail_t *av
     vq->cookie = cookie;
 }
 
-void virtqueue_init_desc_table(volatile vq_vring_desc_t *table)
+void virtqueue_init_desc_table(vq_vring_desc_t *table)
 {
     unsigned i;
     for (i = 0; i < DESC_TABLE_SIZE; i++) {
@@ -48,13 +48,13 @@ void virtqueue_init_desc_table(volatile vq_vring_desc_t *table)
     }
 }
 
-void virtqueue_init_avail_ring(volatile vq_vring_avail_t *ring)
+void virtqueue_init_avail_ring(vq_vring_avail_t *ring)
 {
     ring->flags = 0;
     ring->idx = 0;
 }
 
-void virtqueue_init_used_ring(volatile vq_vring_used_t *ring)
+void virtqueue_init_used_ring(vq_vring_used_t *ring)
 {
     ring->flags = 0;
     ring->idx = 0;

--- a/libvirtqueue/src/virtqueue.c
+++ b/libvirtqueue/src/virtqueue.c
@@ -72,7 +72,11 @@ static unsigned vq_add_desc(virtqueue_driver_t *vq, void *buf, unsigned len,
     }
     vq->free_desc_head = vq->desc_table[new].next;
     desc = vq->desc_table + new;
-    desc->addr = (uint64_t)buf;
+
+    // casting pointers to integers directly is not allowed, must cast the
+    // pointer to a uintptr_t first
+    desc->addr = (uintptr_t)buf;
+
     desc->len = len;
     desc->flags = flag;
     desc->next = DESC_TABLE_SIZE;
@@ -89,7 +93,10 @@ static unsigned vq_pop_desc(virtqueue_driver_t *vq, unsigned idx,
 {
     unsigned next = vq->desc_table[idx].next;
 
-    *buf = (void *)(vq->desc_table[idx].addr);
+    // casting integers to pointers directly is not allowed, must cast the
+    // integer to a uintptr_t first
+    *buf = (void *)(uintptr_t)(vq->desc_table[idx].addr);
+
     *len = vq->desc_table[idx].len;
     *flag = vq->desc_table[idx].flags;
     vq->desc_table[idx].next = vq->free_desc_head;
@@ -190,7 +197,11 @@ int virtqueue_gather_available(virtqueue_device_t *vq, virtqueue_ring_object_t *
     if (idx == DESC_TABLE_SIZE) {
         return 0;
     }
-    *buf = (void *)(vq->desc_table[idx].addr);
+
+    // casting integers to pointers directly is not allowed, must cast the
+    // integer to a uintptr_t first
+    *buf = (void *)(uintptr_t)(vq->desc_table[idx].addr);
+
     *len = vq->desc_table[idx].len;
     *flag = vq->desc_table[idx].flags;
     robj->cur = vq->desc_table[idx].next;


### PR DESCRIPTION
avoid compiler warnings, rewrite code to avoid redundancy