### PR TITLE
Switch the clock settings to an operational state after the init for the sdhc driver

### DIFF
--- a/libsdhcdrivers/include/sdhc/sdio.h
+++ b/libsdhcdrivers/include/sdhc/sdio.h
@@ -23,6 +23,7 @@ typedef void (*sdio_cb)(struct sdio_host_dev *sdio, int status, struct mmc_cmd *
 
 struct sdio_host_dev {
     int (*reset)(struct sdio_host_dev *sdio);
+    int (*set_operational)(struct sdio_host_dev *sdio);
     int (*send_command)(struct sdio_host_dev *sdio, struct mmc_cmd *cmd, sdio_cb cb, void *token);
     int (*handle_irq)(struct sdio_host_dev *sdio, int irq);
     int (*is_voltage_compatible)(struct sdio_host_dev *sdio, int mv);
@@ -68,6 +69,16 @@ static inline int sdio_is_voltage_compatible(sdio_host_dev_t *sdio, int mv)
 static inline int sdio_reset(sdio_host_dev_t *sdio)
 {
     return sdio->reset(sdio);
+}
+
+/**
+ * Set the SDIO device to an operational state
+ * @param[in] sdio A handle to an initialised SDIO driver
+ * @return         0 on success
+ */
+static inline int sdio_set_operational(sdio_host_dev_t *sdio)
+{
+    return sdio->set_operational(sdio);
 }
 
 /**

--- a/libsdhcdrivers/include/sdhc/sdio.h
+++ b/libsdhcdrivers/include/sdhc/sdio.h
@@ -16,6 +16,22 @@
 
 #include <sdhc/plat/sdio.h>
 
+/* Present State Register */
+#define SDHC_PRES_STATE_DAT3         (1 << 23)
+#define SDHC_PRES_STATE_DAT2         (1 << 22)
+#define SDHC_PRES_STATE_DAT1         (1 << 21)
+#define SDHC_PRES_STATE_DAT0         (1 << 20)
+#define SDHC_PRES_STATE_WPSPL        (1 << 19) //Write Protect Switch Pin Level
+#define SDHC_PRES_STATE_CDPL         (1 << 18) //Card Detect Pin Level
+#define SDHC_PRES_STATE_CINST        (1 << 16) //Card Inserted
+#define SDHC_PRES_STATE_BWEN         (1 << 10) //Buffer Write Enable
+#define SDHC_PRES_STATE_RTA          (1 << 9)  //Read Transfer Active
+#define SDHC_PRES_STATE_WTA          (1 << 8)  //Write Transfer Active
+#define SDHC_PRES_STATE_SDSTB        (1 << 3)  //SD Clock Stable
+#define SDHC_PRES_STATE_DLA          (1 << 2)  //Data Line Active
+#define SDHC_PRES_STATE_CDIHB        (1 << 1)  //Command Inhibit(DATA)
+#define SDHC_PRES_STATE_CIHB         (1 << 0)  //Command Inhibit(CMD)
+
 /* TODO turn this into sdio_cmd */
 struct mmc_cmd;
 struct sdio_host_dev;

--- a/libsdhcdrivers/plat_include/exynos4/sdhc/plat/sdio.h
+++ b/libsdhcdrivers/plat_include/exynos4/sdhc/plat/sdio.h
@@ -31,7 +31,7 @@
 #define SDHC4_IRQ   109
 
 enum sdio_id {
-    SDHC0,
+    SDHC0 = 0,
     SDHC1,
     SDHC2,
     SDHC3,

--- a/libsdhcdrivers/src/mmc.c
+++ b/libsdhcdrivers/src/mmc.c
@@ -426,6 +426,13 @@ int mmc_init(sdio_host_dev_t *sdio, ps_io_ops_t *io_ops, mmc_card_t *mmc_card)
         return -1;
     }
 
+    /* Switch host controller to operational settings */
+    if (host_set_operational(mmc)) {
+        LOG_ERROR("Failed to switch the host controller to the operational mode\n");
+        free(mmc);
+        return -1;
+    }
+
     *mmc_card = mmc;
     assert(mmc);
     return 0;

--- a/libsdhcdrivers/src/mmc.h
+++ b/libsdhcdrivers/src/mmc.h
@@ -200,6 +200,11 @@ static inline int host_reset(struct mmc_card *card)
     return sdio_reset(card->sdio);
 }
 
+static inline int host_set_operational(struct mmc_card *card)
+{
+    return sdio_set_operational(card->sdio);
+}
+
 
 
 

--- a/libsdhcdrivers/src/sdhc.c
+++ b/libsdhcdrivers/src/sdhc.c
@@ -161,7 +161,7 @@
 #define readl(a)      (*(volatile uint32_t*)(a))
 
 enum dma_mode {
-    DMA_MODE_NONE,
+    DMA_MODE_NONE = 0,
     DMA_MODE_SDMA,
     DMA_MODE_ADMA
 };
@@ -201,7 +201,7 @@ typedef enum {
 } sdclk_frequency_select;
 
 typedef enum {
-    CLOCK_INITIAL,
+    CLOCK_INITIAL = 0,
     CLOCK_OPERATIONAL
 } clock_mode;
 

--- a/libsdhcdrivers/src/sdhc.c
+++ b/libsdhcdrivers/src/sdhc.c
@@ -705,6 +705,7 @@ static int sdhc_reset(sdio_host_dev_t *sdio)
     /* Reset the host */
     val = readl(host->base + SYS_CTRL);
     val |= SYS_CTRL_RSTA;
+    /* Wait until the controller is ready */
     writel(val, host->base + SYS_CTRL);
     do {
         val = readl(host->base + SYS_CTRL);

--- a/libsdhcdrivers/src/sdhc.c
+++ b/libsdhcdrivers/src/sdhc.c
@@ -155,7 +155,7 @@
 
 /* Watermark Level register */
 #define WTMK_LVL_WR_WML_SHF     16        //Write Watermark Level
-#define WTMK_LVL_RD_WML_SHF     0         //Write Watermark Level
+#define WTMK_LVL_RD_WML_SHF     0         //Read  Watermark Level
 
 #define writel(v, a)  (*(volatile uint32_t*)(a) = (v))
 #define readl(a)      (*(volatile uint32_t*)(a))

--- a/libsdhcdrivers/src/sdhc.h
+++ b/libsdhcdrivers/src/sdhc.h
@@ -10,8 +10,7 @@
  * @TAG(DATA61_BSD)
  */
 
-#ifndef _SDHC_H_
-#define _SDHC_H_
+#pragma once
 
 #include <platsupport/io.h>
 #include <sdhc/sdio.h>
@@ -21,17 +20,15 @@ struct sdhc {
     volatile void *base;
     int version;
     int nirqs;
-    const int* irq_table;
+    const int *irq_table;
     /* Transaction queue */
-    struct mmc_cmd* cmd_list_head;
-    struct mmc_cmd** cmd_list_tail;
+    struct mmc_cmd *cmd_list_head;
+    struct mmc_cmd **cmd_list_tail;
     int blocks_remaining;
     /* DMA allocator */
-    ps_dma_man_t* dalloc;
+    ps_dma_man_t *dalloc;
 };
-typedef struct sdhc* sdhc_dev_t;
+typedef struct sdhc *sdhc_dev_t;
 
-int sdhc_init(void* iobase, const int* irq_table, int nirqs, ps_io_ops_t* io_ops,
-              sdio_host_dev_t* dev);
-
-#endif /* _SDHC_H_ */
+int sdhc_init(void *iobase, const int *irq_table, int nirqs, ps_io_ops_t *io_ops,
+              sdio_host_dev_t *dev);

--- a/libsdhcdrivers/src/services.h
+++ b/libsdhcdrivers/src/services.h
@@ -23,8 +23,7 @@
 #define RESOURCE(o, id) sdhc_map_device(&o->io_mapper, id##_PADDR, id##_SIZE)
 #endif
 
-static inline void
-udelay(long us)
+static inline void udelay(long us)
 {
     ps_udelay(us);
 }
@@ -37,17 +36,15 @@ udelay(long us)
  * @return          the virtual address of the mapping.
  *                  NULL on failure.
  */
-static inline void*
-sdhc_map_device(struct ps_io_mapper* o, uintptr_t paddr, int size)
+static inline void *sdhc_map_device(struct ps_io_mapper *o, uintptr_t paddr, int size)
 {
     return ps_io_map(o, paddr, size, 0, PS_MEM_NORMAL);
 }
 
-static inline void*
-ps_dma_alloc_pinned(ps_dma_man_t *dma_man, size_t size, int align, int cache, ps_mem_flags_t flags,
-                    uintptr_t* paddr)
+static inline void *ps_dma_alloc_pinned(ps_dma_man_t *dma_man, size_t size, int align, int cache, ps_mem_flags_t flags,
+                                        uintptr_t *paddr)
 {
-    void* addr;
+    void *addr;
     assert(dma_man);
     addr = ps_dma_alloc(dma_man, size, align, cache, flags);
     if (addr != NULL) {
@@ -56,8 +53,7 @@ ps_dma_alloc_pinned(ps_dma_man_t *dma_man, size_t size, int align, int cache, ps
     return addr;
 }
 
-static inline void
-ps_dma_free_pinned(ps_dma_man_t *dma_man, void* addr, size_t size)
+static inline void ps_dma_free_pinned(ps_dma_man_t *dma_man, void *addr, size_t size)
 {
     assert(dma_man);
     ps_dma_unpin(dma_man, addr, size);


### PR DESCRIPTION
Looking through the sdhc driver, I noticed that the driver never switches from the initialization clock settings to a higher clock rate for an operational state. Adding the switch improved our read/write speeds on the boards we used for testing. 
In addition to that, a few commits clean up some minor inconsistencies. 
Looking forward to your review/feeback!  